### PR TITLE
CONTRIBUTING.md: fix relative links pointing outside tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This page is for potential contributors to this project. It provides basic infor
 
 This project uses an agile approach for development, where we focus on implementing the 20% of the functionality that solves 80% of the problem. We’re trying to focus on the core capabilities that are needed to provide the greatest amount of benefit. Because we’re working on a small set of capabilities, this allows us to make very fast progress. We’re building the features that we believe solve the biggest problems to provide the most value. We provide extension points that allow uncovered cases to be supported by others.
 
-We track our current work items using GitHub [project cards](../../projects). Our active project is typically the lowest numbered open project within the previously referenced page.
+We track our current work items using GitHub [project cards](https://github.com/usnistgov/vulntology/projects). Our active project is typically the lowest numbered open project within the previously referenced page.
 
 ## Making Contributions
 
@@ -22,10 +22,10 @@ For more information on the project's current needs and priorities, see the proj
 
 ## Issue reporting and handling
 
-All requests for changes and enhancements to the repository are initiated through the project's [GitHub issue tracker](../../issues). To initiate a request, please [create a new issue](https://help.github.com/articles/creating-an-issue/). The following issue templates exist for creating a new issue:
-* [User Story](../../issues/new?template=feature_request.md&labels=enhancement%2C+User+Story): Use to describe a new feature or capability to be added to the project.
-* [Defect Report](../../issues/new?template=bug_report.md&labels=bug): Use to report a problem with an existing feature or capability.
-* [Question](../../issues/new?labels=question&template=question.md): Use to ask a question about the project or the contents of the repository.
+All requests for changes and enhancements to the repository are initiated through the project's [GitHub issue tracker](https://github.com/usnistgov/vulntology/issues). To initiate a request, please [create a new issue](https://help.github.com/articles/creating-an-issue/). The following issue templates exist for creating a new issue:
+* [User Story](https://github.com/usnistgov/vulntology/issues/new?template=feature_request.md&labels=enhancement%2C+User+Story): Use to describe a new feature or capability to be added to the project.
+* [Defect Report](https://github.com/usnistgov/vulntology/issues/new?template=bug_report.md&labels=bug): Use to report a problem with an existing feature or capability.
+* [Question](https://github.com/usnistgov/vulntology/issues/new?labels=question&template=question.md): Use to ask a question about the project or the contents of the repository.
 
 The project team regularly reviews the open issues, prioritizes their handling, and updates the issue statuses, proving comments on the current status as needed.
 
@@ -52,11 +52,11 @@ This repository consists of the following directories and files pertaining to th
 
 ## Contributing to a Development Sprint
 
-This project is using the GitHub [project cards](../../projects) feature to track development sprints as part of the core project work stream. A typical development sprint lasts roughly a month, with some sprints lasting slightly less or more to work around major holidays or events attended by the core project team. The active sprint is typically the lowest numbered open project within the previously referenced page.
+This project is using the GitHub [project cards](https://github.com/usnistgov/vulntology/projects) feature to track development sprints as part of the core project work stream. A typical development sprint lasts roughly a month, with some sprints lasting slightly less or more to work around major holidays or events attended by the core project team. The active sprint is typically the lowest numbered open project within the previously referenced page.
 
 ### User Stories
 
-Each development sprint consists of a set of [user stories](../../issues?q=is%3Aopen+is%3Aissue+label%3A%22User+Story%22), that represent features, actions, or enhancements that are intended to be developed during the sprint. Each user story is based on a [template](../../issues/new?template=feature_request.md&labels=enhancement%2C+User+Story) and describes the basic problem or need to be addressed, a set of detailed goals to accomplish, any dependencies that must be addressed to start or complete the user story, and the criteria for acceptance of the contribution.
+Each development sprint consists of a set of [user stories](https://github.com/usnistgov/vulntology/issues?q=is%3Aopen+is%3Aissue+label%3A%22User+Story%22), that represent features, actions, or enhancements that are intended to be developed during the sprint. Each user story is based on a [template](https://github.com/usnistgov/vulntology/issues/new?template=feature_request.md&labels=enhancement%2C+User+Story) and describes the basic problem or need to be addressed, a set of detailed goals to accomplish, any dependencies that must be addressed to start or complete the user story, and the criteria for acceptance of the contribution.
 
 The goals in a user story will be bulleted, indicating that each goal can be worked on in parallel, or numbered, indicating that each goal must be worked on sequentially. Each goal will be assigned to one or more individuals to accomplish.
 


### PR DESCRIPTION
These links point to things that only exist for the specific repository
<https://github.com/usnistgov/vulntology/>;
they CAN'T POSSIBLY work in clones or forks,
and while the fact that it does work on
<https://github.com/usnistgov/vulntology/blob/main/CONTRIBUTING.md>
itself might be an intended feature of GitHub,
it's not really explained in the documentation.

Thus, convert them to absolute form, which will make sense anywhere.